### PR TITLE
Python3 compatible StringIO import.

### DIFF
--- a/pagination_bootstrap/tests.py
+++ b/pagination_bootstrap/tests.py
@@ -1,4 +1,7 @@
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.paginator import Paginator


### PR DESCRIPTION
This should help resolve tests from failing in Python3