### PR TITLE
readme links of image tags on top

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,16 @@
 |Travis| |Python27| |Python35| |PyPi|
 
 .. |Travis| image:: https://api.travis-ci.org/staticdev/django-pagination-bootstrap.svg?branch=master
-.. _Travis: https://travis-ci.org/staticdev/django-pagination-bootstrap
+    :target: https://travis-ci.org/staticdev/django-pagination-bootstrap
 
 .. |Python27| image:: https://img.shields.io/badge/python-2.7-blue.svg
-.. _Python27: https://badge.fury.io/py/django-pagination-bootstrap
+   :target: https://badge.fury.io/py/django-pagination-bootstrap
 
 .. |Python35| image:: https://img.shields.io/badge/python-3.5-blue.svg
-.. _Python35: https://badge.fury.io/py/django-pagination-bootstrap
+   :target: https://badge.fury.io/py/django-pagination-bootstrap
 
 .. |PyPi| image:: https://badge.fury.io/py/django-pagination-bootstrap.svg
-.. _PyPi: https://badge.fury.io/py/django-pagination-bootstrap
+   :target: https://badge.fury.io/py/django-pagination-bootstrap
 
 
 django-pagination-bootstrap


### PR DESCRIPTION
They were linking to the images themselves. I'm not familiar with RST, but this fixes the links to point to the destination websites