### PR TITLE
Test to use TEMPLATES vs TEMPLATE_CONTEXT_PROCESSORS depending on django version

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -3,7 +3,7 @@
 import sys
 import django
 from django.conf import settings
-
+from django import get_version
 
 APP_NAME = 'pagination_bootstrap'
 
@@ -28,14 +28,39 @@ settings.configure(
         'django.contrib.sites',
         APP_NAME,
     ),
-    TEMPLATE_CONTEXT_PROCESSORS = (
-        "django.contrib.auth.context_processors.auth",
-        "django.core.context_processors.debug",
-        "django.core.context_processors.i18n",
-        "django.core.context_processors.media",
-        "django.core.context_processors.request",
-    ),
 )
+
+# set TEMPLATE_CONTEXT_PROCESSORS or TEMPLATES, based on django version
+# http://stackoverflow.com/a/16805125/4126114
+if get_version() < '1.8':
+    settings.configure(
+        TEMPLATE_CONTEXT_PROCESSORS = (
+            "django.contrib.auth.context_processors.auth",
+            "django.core.context_processors.debug",
+            "django.core.context_processors.i18n",
+            "django.core.context_processors.media",
+            "django.core.context_processors.request",
+        ),
+    )
+else:
+    settings.configure(
+        TEMPLATES = [
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [],
+                "APP_DIRS": True,
+                "OPTIONS": {
+                    "context_processors": [
+                        "django.contrib.auth.context_processors.auth",
+                        "django.template.context_processors.debug",
+                        "django.template.context_processors.i18n",
+                        "django.template.context_processors.media",
+                        "django.template.context_processors.request",
+                    ],
+                },
+            },
+        ]
+    )
 
 from django.test.utils import get_runner
 


### PR DESCRIPTION
Related to https://github.com/staticdev/django-pagination-bootstrap/pull/21#issuecomment-288547578

Note that this is not tested, as I am not familiar with Tox