### PR TITLE
Django 1.10 paginator doesn't seem to have _num_pages and _count attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ matrix:
       env: DJANGO="Django>=1.7.0,<1.8.0"
     - python: "3.3"
       env: DJANGO="Django>=1.9.0,<1.10.0"
+    - python: "3.3"
+      env: DJANGO="Django>=1.10.0,<1.11.0"

--- a/pagination_bootstrap/paginator.py
+++ b/pagination_bootstrap/paginator.py
@@ -16,8 +16,11 @@ class InfinitePaginator(Paginator):
         orphans = 0 # no orphans
         super(InfinitePaginator, self).__init__(object_list, per_page, orphans,
             allow_empty_first_page)
-        # no count or num pages
-        del self._num_pages, self._count
+        try:
+            # no count or num pages
+            del self._num_pages, self._count
+        except:
+            pass
         # bonus links
         self.link_template = link_template
 


### PR DESCRIPTION
This pull request passes all tests.